### PR TITLE
Fix displaying ACTION messages

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -42,8 +42,30 @@ module IRC_Log
         @views[path] ||= File.read("#{__dir__}/views/#{path}.erb")
       end
 
-      def user_text text
-        autolink(CGI.escape_html(text))
+      def action? msg
+        msg['msg'] =~ /^\u0001ACTION (.*)\u0001$/
+      end
+
+      def escape text
+        CGI.escape_html(text)
+      end
+
+      def user_nick msg
+        if action?(msg)
+          '*'
+        else
+          escape(msg['nick'])
+        end
+      end
+
+      def user_text msg
+        if action?(msg)
+          act  = escape(msg['msg'][/^\u0001ACTION (.*)\u0001$/, 1])
+          nick = escape(msg['nick'])
+          "<span class=\"nick\">#{nick}</span>&nbsp;#{act}"
+        else
+          autolink(escape(msg['msg']))
+        end
       end
 
       def autolink text
@@ -76,20 +98,13 @@ module IRC_Log
       @channel = m[:channel]
 
       @msgs = $redis.lrange("irclog:channel:##{@channel}:#{@date}", 0, -1).
-        map {|msg|
-          msg = JSON.parse(msg)
-          if msg["msg"] =~ /^\u0001ACTION (.*)\u0001$/
-            msg["msg"].gsub!(/^\u0001ACTION (.*)\u0001$/, "<span class=\"nick\">#{msg["nick"]}</span>&nbsp;\\1")
-            msg["nick"] = "*"
-          end
-          if m[:format] == 'json'
-            msg["time"] = Time.at(msg["time"].to_f).strftime("%F %T")
-          end
-          msg
-        }
+        map{ |msg| JSON.parse(msg) }
 
       if m[:format] == 'json'
         headers_merge('Content-Type' => 'application/json')
+        @msgs.each do |msg|
+          msg['time'] = Time.at(msg['time'].to_f).strftime('%F %T')
+        end
         @msgs.to_json
       else
         erb :channel
@@ -105,10 +120,7 @@ module IRC_Log
       if 0 > @line or @line >= msgs.length
         not_found
       end
-      msg = JSON.parse(msgs[@line])
-      @nick = msg["nick"]
-      @msg  = msg["msg"]
-      @time = msg["time"].to_f
+      @msg  = JSON.parse(msgs[@line])
       @url = CGI.escape(request.url)
 
       erb :quote

--- a/views/_embed.erb
+++ b/views/_embed.erb
@@ -1,7 +1,7 @@
 <blockquote class="logbot">
-  <p class="msg"><%= @msg %></p>
+  <p class="msg"><%= user_text(@msg) %></p>
   <footer>
-    <span class="nick"><%= @nick %></span>
-    <a class="time" href="<%= "/channel/#{@channel}/#{@date}##{@line}" %>" target="_self" title="<%= "##{@line}" %>"><%= Time.at(@time).strftime("%T") %></a>
+    <span class="nick"><%= user_nick(@msg) %></span>
+    <a class="time" href="<%= "/channel/#{@channel}/#{@date}##{@line}" %>" target="_self" title="<%= "##{@line}" %>"><%= Time.at(@msg['time'].to_f).strftime("%T") %></a>
   </footer>
 </blockquote>

--- a/views/channel.erb
+++ b/views/channel.erb
@@ -37,11 +37,11 @@
 
         <div>
           <ul class="logs">
-            <% @msgs.each_index do |i| %>
+            <% @msgs.each.with_index do |m, i| %>
               <li id="<%= i %>">
-                <a class="time" href="<%= "#{@date}##{i}" %>" target="_self" title="<%= "##{i}" %>"><%= Time.at(@msgs[i]["time"].to_f).strftime("%T") %></a>
-                <a class="nick" href="<%= "#{@date}/#{i}" %>" target="_self" title="<%= @msgs[i]["nick"] %>"><%= @msgs[i]["nick"] %></a>
-                <span class="msg wordwrap"><%= user_text(@msgs[i]["msg"]) %></span>
+                <a class="time" href="<%= "#{@date}##{i}" %>" target="_self" title="<%= "##{i}" %>"><%= Time.at(m['time'].to_f).strftime('%T') %></a>
+                <a class="nick" href="<%= "#{@date}/#{i}" %>" target="_self" title="<%= user_nick(m) %>"><%= user_nick(m) %></a>
+                <span class="msg wordwrap"><%= user_text(m) %></span>
               </li>
             <% end %>
           </ul>

--- a/views/live.erb
+++ b/views/live.erb
@@ -19,12 +19,12 @@
       <div class="body">
         <div>
           <ul class="logs">
-            <% @msgs.each_index do |i| %>
+            <% @msgs.each.with_index do |m, i| %>
               <% index = @msgs.length - 1 - i %>
               <li id="<%= index %>">
-                <a class="time" href="<%= "##{index}" %>" target="_self" title="<%= "##{index}" %>"><%= Time.at(@msgs[i]["time"].to_f).strftime("%T") %></a>
-                <span class="nick"><%= @msgs[i]["nick"] %></span>
-                <span class="msg wordwrap"><%= user_text(@msgs[i]["msg"]) %></span>
+                <a class="time" href="<%= "##{index}" %>" target="_self" title="<%= "##{index}" %>"><%= Time.at(m['time'].to_f).strftime('%T') %></a>
+                <span class="nick"><%= user_nick(m) %></span>
+                <span class="msg wordwrap"><%= user_text(m) %></span>
               </li>
             <% end %>
           </ul>

--- a/views/oembed.erb
+++ b/views/oembed.erb
@@ -2,7 +2,7 @@
 <oembed>
   <version>1.0</version>
   <type>link</type>
-  <title>Logbot | #<%= @channel %> | <%= @nick %>&gt; <%= @msg %></title>
+  <title>Logbot | #<%= @channel %> | <%= @nick %>&gt; <%= escape(@msg) %></title>
   <author_name><%= @nick %></author_name>
   <provider_name>Logbot</provider_name>
   <provider_url><%= request.base_url %></provider_url>

--- a/views/quote.erb
+++ b/views/quote.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Logbot | #<%= @channel %> | <%= @nick %>&gt; <%= @msg %></title>
+    <title>Logbot | #<%= @channel %> | <%= user_nick(@msg) %>&gt; <%= user_text(@msg) %></title>
     <link rel="alternate" type="application/json+oembed"
       href="/oembed.json?url=<%= @url %>"
       title="<%= @title %>" />

--- a/views/widget.erb
+++ b/views/widget.erb
@@ -14,12 +14,12 @@
       <div class="body">
         <div>
           <ul class="logs">
-            <% @msgs.each_index do |i| %>
+            <% @msgs.each.with_index do |m, i| %>
               <% index = @msgs.length - 1 - i %>
               <li id="<%= index %>">
-                <a class="time" href="<%= "##{index}" %>" target="_self" title="<%= "##{index}" %>"><%= Time.at(@msgs[i]["time"].to_f).strftime("%T") %></a>
-                <span class="nick"><%= @msgs[i]["nick"] %></span>
-                <span class="msg wordwrap"><%= user_text @msgs[i]["msg"] %></span>
+                <a class="time" href="<%= "##{index}" %>" target="_self" title="<%= "##{index}" %>"><%= Time.at(m["time"].to_f).strftime("%T") %></a>
+                <span class="nick"><%= user_nick(m) %></span>
+                <span class="msg wordwrap"><%= user_text(m) %></span>
               </li>
             <% end %>
           </ul>


### PR DESCRIPTION
Previously it would show HTML tags for ACTION logs, now we handle that properly. Also tried to escape a number of user inputs.

On the other hand, /live/g0v pages are also fixed from crashing, but I am still seeing empty pages for that. Not sure what I am supposed to see?
