### PR TITLE
change the mask of nickname color for better look, and add parser for message color

### DIFF
--- a/public/applications.js
+++ b/public/applications.js
@@ -176,8 +176,8 @@ var parseColor = function() {
             }
             return true;
           });
-          console.log(JSON.stringify(text));
-          console.log(JSON.stringify(stylefrag));
+          //console.log(JSON.stringify(text));
+          //console.log(JSON.stringify(stylefrag));
           //insert styles into list and remove parsed tag
           temp.splice(i, 1, styles);
         }


### PR DESCRIPTION
效果圖
![效果圖](http://puu.sh/b8FNI/bf049a2865.png)

live demo
http://log.ysitd.ba4b.net/

nickname color mask的更改
更改mask成指定每一色第2跟第3 bit為10，也即是數值 0b0100 0000 到 0b1101 1111 間
這樣的話，每一色顏色強度會被限制在 64~223 間
明亮很多，而且也比較容易辨識

color parser則是使log支援irc的標準色碼
詳細格式見
https://github.com/myano/jenni/wiki/IRC-String-Formatting
有實作的部分是 前後景色、粗體、底線、斜體、重設
反白的部分則沒真的實作，因為目前大部分client似乎都不支援
實作的意義也不大
