### PR TITLE
make date picker able to select other days

### DIFF
--- a/views/channel.erb
+++ b/views/channel.erb
@@ -66,7 +66,12 @@
       var channel = "<%= @channel %>";
       var currentDay = "<%= @date %>";
       var today = "<%= Date.today.to_s %>";
-      $( "#date-picker" ).val( currentDay );
+      //sometimes browser remember last chosen option and cause strange result
+      if ($("#today").text() === currentDay) {
+        $( "#date-picker" ).val( "today" );
+      } else {
+        $( "#date-picker" ).val( currentDay );
+      }
     </script>
     <script src="/assets/applications.js?"></script>
     <script src="/assets/md5.min.js"></script>


### PR DESCRIPTION
Make us able to select date that not in the options.
Use input[type=date] in browser support html5 input type,
and use jQueryUI date picker in browser that doesn't support that.
preview : 
![cd6f435825](https://cloud.githubusercontent.com/assets/2993977/4518444/91de7de8-4c8d-11e4-8053-db276ce28ba5.png)
